### PR TITLE
Resize redis disk

### DIFF
--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -17,6 +17,10 @@ postgresql: &postgres
   # asdf
   #     cpu: 2
 
+  # Set this based on Prerequisites: https://docs.openreplay.com/deployment/deploy-kubernetes
+  persistence:
+      size: 50Gi
+
 clickhouse:
   # For enterpriseEdition
   enabled: false
@@ -49,6 +53,10 @@ redis: &redis
   # enabled: false
   redisHost: "redis-master.openreplay.svc.cluster.local"
   redisPort: "6379"
+  # Set this based on Prerequisites: https://docs.openreplay.com/deployment/deploy-kubernetes
+  master:
+    persistence:
+      size: 50Gi
 
 minio:
   # If you have extrenal s3 storage, like AWS, or GCP

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -184,28 +184,122 @@ chalice:
 #       cpu: 512m
 #       memory: 2056Mi
 
-# override defautl variables
+# Override Some Defautl Variables
+alerts:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+assets:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
 assist:
   ingress:
     tls:
       secretName: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
 chalice:
   ingress:
     tls:
       secretName: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+db:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+ender:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
 frontend:
   ingress:
     tls:
       secretName: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+heuristics:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
 http:
   ingress:
     tls:
       secretName: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+integrations:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
 peers:
   ingress:
     tls:
       secretName: ""
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+sink:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+storage:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -106,6 +106,19 @@ ingress-nginx: &ingress-nginx
       ssl-redirect: true
       force-ssl-redirect: true
       proxy-body-size: 10m
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 50
+      targetMemoryUtilizationPercentage: 50
+    nodeSelector:
+      Dedicated: openreplay-dev
+    tolerations:
+    - key: dedicated
+      operator: "Equal"
+      value: openreplay
+      effect: NoSchedule
 
 # Application specific variables
 global:
@@ -189,17 +202,31 @@ alerts:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 assets:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 assist:
   ingress:
@@ -208,9 +235,16 @@ assist:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 chalice:
   ingress:
@@ -219,25 +253,46 @@ chalice:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 db:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 ender:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 frontend:
   ingress:
@@ -246,17 +301,31 @@ frontend:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 heuristics:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 http:
   ingress:
@@ -265,17 +334,31 @@ http:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 integrations:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 peers:
   ingress:
@@ -284,22 +367,43 @@ peers:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 sink:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule
 
 storage:
   autoscaling:
     enabled: true
     minReplicas: 1
-    maxReplicas: 2
+    maxReplicas: 4
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+  nodeSelector:
+      Dedicated: openreplay-dev
+  tolerations:
+  - key: dedicated
+    operator: "Equal"
+    value: openreplay
+    effect: NoSchedule


### PR DESCRIPTION
OpenReplay got a Issue about disk of redis. I am resized it and set `autoscaling` to the openreplay

```
  Normal   NodeHasNoDiskPressure  16m (x7 over 34d)   kubelet  Node ip-10-21-27-79.ec2.internal status is now: NodeHasNoDiskPressure
  Normal   NodeHasDiskPressure    13m (x6 over 18d)   kubelet  Node ip-10-21-27-79.ec2.internal status is now: NodeHasDiskPressure
  Warning  EvictionThresholdMet   11m (x19 over 18d)  kubelet  Attempting to reclaim ephemeral-storage
  Warning  ImageGCFailed          9m5s (x3 over 19m)  kubelet  (combined from similar events): failed to garbage collect required amount of images. Wanted to free 2081073561 bytes, but freed 307135020 bytes
  Warning  FreeDiskSpaceFailed    4m5s (x5 over 24m)  kubelet  (combined from similar events): failed to garbage collect required amount of images. Wanted to free 2110957977 bytes, but freed 0 bytes
```

![image](https://user-images.githubusercontent.com/113869810/205945478-6e3d96cd-8119-4697-bbf9-b8be36e306e1.png)
